### PR TITLE
Add pwd path to jar's one

### DIFF
--- a/dex-method-counts
+++ b/dex-method-counts
@@ -14,7 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-libdir="build/jar"
+curdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+libdir="$curdir/build/jar"
 jarfile="dex-method-counts.jar"
 if [ ! -r "$libdir/$jarfile" ]
 then


### PR DESCRIPTION
The flow is:
1. clone repo e.g. to `~/android/tools/dex-count`
2. give shell the alias like ```alias DEX_COUNT="~/android/tools/dex-count/dex-method-counts"
->
Run from your android-project root DEX_COUNT app/build/outputs/apk/myapp.apk
