### PR TITLE
Update README with all supported options and change name of output-style to match convention.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,12 @@ You'll see output of the form:
 
 Supported options are:
 
+* `--count-fields`: Provide the field count instead of the method count.
 * `--include-classes`: Treat classes as packages and provide per-class method counts. One use-case is for protocol buffers where all generated code in a package ends up in a single class.
-* `--package-filter=...`: Only consider methods whose fullly qualified name starts with this prefix.
+* `--package-filter=...`: Only consider methods whose fully qualified name starts with this prefix.
 * `--max-depth=...`: Limit how far into package paths (or inner classes, with `--include-classes`) counts should be reported for.
 * `--filter=[all|defined_only|referenced_only]`: Whether to count all methods (the default), just those defined in the input file, or just those that are referenced in it. Note that referenced methods count against the 64K method limit too.
+* `--output-style=[flat|tree]`: Print the output as a list or as an indented tree.
 
 The DEX file parsing is based on the `dexdeps` tool from
 [the Android source tree](https://android.googlesource.com/platform/dalvik.git/+/master/tools/dexdeps/).

--- a/src/info/persistent/dex/Main.java
+++ b/src/info/persistent/dex/Main.java
@@ -178,7 +178,7 @@ public class Main {
                 filter = Enum.valueOf(
                     DexMethodCounts.Filter.class,
                     arg.substring(arg.indexOf('=') + 1).toUpperCase());
-            } else if (arg.startsWith("--output_style")) {
+            } else if (arg.startsWith("--output-style")) {
                 outputStyle = Enum.valueOf(
                     DexMethodCounts.OutputStyle.class,
                     arg.substring(arg.indexOf('=') + 1).toUpperCase());
@@ -208,7 +208,7 @@ public class Main {
             "  --package-filter=com.foo.bar\n" +
             "  --max-depth=N\n" +
             "  --filter=ALL|DEFINED_ONLY|REFERENCED_ONLY\n" +
-            "  --output_style=FLAT|TREE\n"
+            "  --output-style=FLAT|TREE\n"
         );
     }
 


### PR DESCRIPTION
Changes:

* The `README` has been updated with the full list of options.
* The option `output_style` has been renamed to `output-style` to match the established naming convention.