### PR TITLE
Allow passing of multiple arguments.

### DIFF
--- a/dex-method-counts.bat
+++ b/dex-method-counts.bat
@@ -1,1 +1,1 @@
-java -jar build\jar\dex-method-counts.jar %1
+java -jar build\jar\dex-method-counts.jar %*


### PR DESCRIPTION
By using `%1` it was impossible to use arguments with the bat file.  A call like:
```
dex-method-counts.bat --output-style=flat my.apk
```
would result in 
```
Exception in thread "main" java.lang.IllegalArgumentException: No enum constant info.persistent.dex.DexCount.OutputStyle.--OUTPUT-STYLE
```

This change to the bat file passes all arguments to the java call, allowing the above example to work.