### PR TITLE
fix that default pkg's method count is at most 1

### DIFF
--- a/src/info/persistent/dex/DexMethodCounts.java
+++ b/src/info/persistent/dex/DexMethodCounts.java
@@ -49,6 +49,8 @@ public class DexMethodCounts extends DexCount {
                     String name = packageNamePieces[i];
                     if (packageNode.children.containsKey(name)) {
                         packageNode = packageNode.children.get(name);
+                    } else if (packageNode.children.containsKey("<default>") && "".equals(name)) {
+                        packageNode = packageNode.children.get("<default>");
                     } else {
                         Node childPackageNode = new Node();
                         if (name.length() == 0) {


### PR DESCRIPTION
**Bug description**: No matter how many default package methods there are, the printed result is always 1 for default package methods count. **Explanation**: The name in line 49 may be "", which means corresponding method is from default package. For the default package methods, code runs into else branch since no child has name "". Therefore, for every default package method, a new Node is created in line 53. For non-first default package method, the newly created Node will always replace the former Node in line 59, and get its count equals 1 in line 63. Overall, method count of default package is always at most 1. I added an else if branch, which avoids making new Node if we already has a <default> Node when the coming method is a default package method.